### PR TITLE
Correct comparison operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Objects in JavaScript are similar to dictionaries in Python (key-value pairs).
 - `=`, `+=`, `-=`, `/=`, `%=`, `*=`, `**=`
 
 ### Comparison Operators
-- `=`: Assignment operator.
 - `==`: Equal to (does not check the type).
 - `!=`: Not equal to (does not check the type).
 - `===`: Equal value and equal type.


### PR DESCRIPTION
The changes I made include:

- Remove the `assignment operator (=)` from the `comparison operators` section.

Closes #11 